### PR TITLE
Feature/score adjustment

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -4261,6 +4261,10 @@ static void maybe_delete_out_dir(void) {
   if (unlink(fn) && errno != ENOENT) goto dir_cleanup_failed;
   ck_free(fn);
 
+  fn = alloc_printf("%s/unique_dafl.log", out_dir);
+  if (unlink(fn) && errno != ENOENT) goto dir_cleanup_failed;
+  ck_free(fn);
+
   OKF("Output dir cleanup successful.");
 
   /* Wow... is that all? If yes, celebrate! */

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1232,10 +1232,6 @@ static u8 recompute_proximity_score(struct queue_entry* q) {
   /**
    * Recalculate the proximity score of the input entry
   */
-  if (q->prox_score.dfg_count_map) {
-    compute_proximity_score(&q->prox_score, q->prox_score.dfg_count_map, 0);
-    return 1;
-  }
   if (q->prox_score.dfg_dense_map) {
     double adjusted_score = .0;
     for (u32 i = 0; i < q->prox_score.total; i++) {
@@ -1247,7 +1243,12 @@ static u8 recompute_proximity_score(struct queue_entry* q) {
     q->prox_score.adjusted = adjusted_score;
     return 0;
   }
+  if (q->prox_score.dfg_count_map) {
+    compute_proximity_score(&q->prox_score, q->prox_score.dfg_count_map, 0);
+    return 1;
+  }
   // This should not happen
+  WARNF("Invalid proximity_score for recomputation: testcase %u", q->entry_id);
   return 2;
 }
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -243,7 +243,7 @@ static FILE* plot_file;               /* Gnuplot output file              */
 
 static double *proximity_score_cache = NULL; /* Cache for proximity scores */
 static double proximity_score_reduction = 0.05 /* Reduction factor for proximity scores */;
-static u32 max_queue_size = 64;          /* Maximum input in queue            */
+static u32 max_queue_size = 4096;          /* Maximum input in queue            */
 
 struct proximity_score {
   u64 original;
@@ -923,6 +923,8 @@ static void sort_queue(void) {
 
 EXP_ST void destroy_queue_entry(struct queue_entry* q, u8 only_prox_score) {
 
+  q->removed = 1;
+
   ck_free(q->prox_score.dfg_count_map);
   q->prox_score.dfg_count_map = NULL;
 
@@ -1349,7 +1351,7 @@ static void update_dfg_score(struct queue_entry *q_preserve) {
         total_prox_score.original -= q_remove->prox_score.original;
         total_prox_score.adjusted -= q_remove->prox_score.adjusted;
         destroy_queue_entry(q_remove, 1);
-        q_remove->removed = 1;
+        // Should we reduce the count of the dfg_count_map?
         if (not_on_tty) {
           SAYF("Remove entry from queue: %u, orig: %llu, adj: %f, total: %u\n", q_remove->entry_id, q_remove->prox_score.original, q_remove->prox_score.adjusted, q_remove->prox_score.total);
         }

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -920,12 +920,16 @@ static void sort_queue(void) {
 
 }
 
-EXP_ST void destroy_queue_entry(struct queue_entry* q) {
-  ck_free(q->fname);
-  ck_free(q->trace_mini);
+EXP_ST void destroy_queue_entry(struct queue_entry* q, u8 only_prox_score) {
+  
   if (q->prox_score.dfg_count_map) ck_free(q->prox_score.dfg_count_map);
   if (q->prox_score.dfg_dense_map) ck_free(q->prox_score.dfg_dense_map);
+  if (only_prox_score) return;
+
+  ck_free(q->fname);
+  ck_free(q->trace_mini);
   ck_free(q);
+
 }
 
 
@@ -938,7 +942,7 @@ EXP_ST void destroy_queue(void) {
   while (q) {
 
     n = q->next;
-    destroy_queue_entry(q);
+    destroy_queue_entry(q, 0);
     q = n;
 
   }
@@ -1331,9 +1335,14 @@ static void update_dfg_score(struct queue_entry *q_preserve) {
     while (q_remove) {
       q_next = q_remove->next;
       if (q_remove != q_preserve) {
+        if (q_remove == first_unhandled)
+          first_unhandled = q_preserve;
         total_prox_score.original -= q_remove->prox_score.original;
         total_prox_score.adjusted -= q_remove->prox_score.adjusted;
-        destroy_queue_entry(q_remove);
+        destroy_queue_entry(q_remove, 1);
+        if (not_on_tty) {
+          SAYF("Remove entry from queue: %u, orig: %llu, adj: %f, total: %u\n", q_remove->entry_id, q_remove->prox_score.original, q_remove->prox_score.adjusted, q_remove->prox_score.total);
+        }
       } else {
         revert_remove = 1;
       }

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1386,7 +1386,7 @@ static void update_dfg_score(struct queue_entry *q_preserve) {
       q_next = q_remove->next;
       if (q_remove != q_preserve) {
         if (q_remove == first_unhandled)
-          first_unhandled = q_preserve;
+          first_unhandled = NULL;
         total_prox_score.original -= q_remove->prox_score.original;
         total_prox_score.adjusted -= q_remove->prox_score.adjusted;
         destroy_queue_entry(q_remove, 1);

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -242,7 +242,7 @@ static s32 cpu_aff = -1;       	      /* Selected CPU core                */
 static FILE* plot_file;               /* Gnuplot output file              */
 
 static double *proximity_score_cache = NULL; /* Cache for proximity scores */
-static double proximity_score_reduction = 0.05 /* Reduction factor for proximity scores */;
+static double proximity_score_reduction = 0.02; /* Reduction factor for proximity scores */
 static u32 max_queue_size = 4096;          /* Maximum input in queue            */
 
 struct proximity_score {
@@ -8160,7 +8160,7 @@ int main(int argc, char** argv) {
   gettimeofday(&tv, &tz);
   srandom(tv.tv_sec ^ tv.tv_usec ^ getpid());
 
-  while ((opt = getopt(argc, argv, "+i:o:f:m:t:T:dnCB:S:M:x:QNc:")) > 0)
+  while ((opt = getopt(argc, argv, "+i:o:f:m:t:T:dnCB:S:M:x:QNc:r:")) > 0)
 
     switch (opt) {
 
@@ -8348,6 +8348,11 @@ int main(int argc, char** argv) {
           }
         }
 
+        break;
+      
+      case 'r': /* Parameter to test different proximity score reduction ratio */
+        
+        proximity_score_reduction = atof(optarg);
         break;
 
       default:

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -1664,7 +1664,7 @@ static void cull_queue(void) {
      If yes, and if it has a top_rated[] contender, let's use it. */
 
   for (i = 0; i < MAP_SIZE; i++)
-    if (top_rated[i] && (temp_v[i >> 3] & (1 << (i & 7)))) {
+    if (top_rated[i] && !top_rated[i]->removed && (temp_v[i >> 3] & (1 << (i & 7)))) {
 
       u32 j = MAP_SIZE >> 3;
 


### PR DESCRIPTION
Adjust score for previously covered nodes. Maintain a fixed queue size (4096) and recompute the DFG score every time an interesting test case is found.
AFL_NO_UI=1 /home/yuntong/vulnfix/thirdparty/DAFL/afl-fuzz -C -t 2000ms -m none -i ./in -o ./out -r 0.03 -- ./tiffcrop.instrumented @@ /tmp/out.tmp
Use the -r option to adjust the reduction ratio.
